### PR TITLE
Remap console calls to connection console calls

### DIFF
--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -3,6 +3,10 @@ import { Server } from './server';
 
 const connection = createConnection(ProposedFeatures.all);
 
+console.log = connection.console.log.bind(connection.console);
+console.info = connection.console.info.bind(connection.console);
+console.error = connection.console.error.bind(connection.console);
+
 new Server(connection);
 
 connection.listen();


### PR DESCRIPTION
LSP clients such as one for Sublime Text handle [anything non-JSON in language server output compliant as error](https://github.com/sublimelsp/LSP/pull/2296) which is probably a good thing since we should expect proper output for language server client at all times, and any error should crash server.

Twiggy language server uses output to print log information such as result of using PHP bin command which messes up JSON parser.

This PR remaps console calls to connection calls, similar to how [Sass language server does it](https://github.com/wkillerud/some-sass/blob/eab00574065b210605013e3733f6ed971389c082/packages/language-server/src/node-server.ts#L7-L8).

Addresses https://github.com/moetelo/twiggy/issues/7#issuecomment-2003176566