### PR TITLE
Add valid language server bin distribution file

### DIFF
--- a/packages/language-server/bin/server.js
+++ b/packages/language-server/bin/server.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+const path = require('path');
+require(path.resolve(__dirname, '../dist/server.js'));

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -3,15 +3,16 @@
   "version": "0.6.6",
   "author": "Mikhail Gunin <gunka462@gmail.com>",
   "license": "Mozilla Public License 2.0",
-  "main": "dist/index.js",
+  "main": "dist/server.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/moetelo/twiggy.git",
     "directory": "packages/language-server"
   },
-  "bin": "./dist/server.js",
+  "bin": "bin/server.js",
   "files": [
     "dist/",
+    "bin/",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
Follow up to https://github.com/moetelo/twiggy/issues/7#issuecomment-1999665404

This PR adds additional bin file which should cover all cases where runtime should be Node regardless of how the command is called from the shell.

Same approach is used in [Sass language server](https://github.com/wkillerud/some-sass/blob/main/packages/language-server/bin/some-sass-language-server).