### PR TITLE
Try to find Craft installation in workspace subfolders

### DIFF
--- a/packages/language-server/phpUtils/printCraftTwigEnvironment.php
+++ b/packages/language-server/phpUtils/printCraftTwigEnvironment.php
@@ -10,6 +10,19 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'getTwigMetadata.php';
 
 [, $WORKSPACE_DIR] = $argv;
 
+// Check if the working dir has a Craft installation
+if (!file_exists($WORKSPACE_DIR . DIRECTORY_SEPARATOR . 'craft')) {
+    // Try to find a Craft installation in subfolders
+    foreach (glob($WORKSPACE_DIR . "/*/craft") as $craftFile) {
+        $workspaceCandidate = dirname($craftFile);
+        // Make sure it has a bootstrap file to verify it is a Craft installation
+        if(file_exists($workspaceCandidate . DIRECTORY_SEPARATOR . 'bootstrap.php')) {
+            $WORKSPACE_DIR = $workspaceCandidate;
+            break;
+        }
+    }
+}
+
 $VENDOR_PATH = $WORKSPACE_DIR . DIRECTORY_SEPARATOR . 'vendor';
 
 require_once $WORKSPACE_DIR . '/bootstrap.php';
@@ -19,9 +32,12 @@ $app = require $VENDOR_PATH . '/craftcms/cms/bootstrap/web.php';
 
 $view = $app->getView();
 $twig = $view->getTwig();
-$templateRoots = $view->getSiteTemplateRoots();
+
+// Add Craft's template path to Twig's loader paths
+$templateRoots = ['' => [$templatesPath ?? 'templates']];
+$templateRoots = array_merge($templateRoots, $view->getSiteTemplateRoots());
 
 $twigMetadata = \Twiggy\Metadata\getTwigMetadata($twig, 'craft');
-$twigMetadata['loader_paths'] = $view->getSiteTemplateRoots();
+$twigMetadata['loader_paths'] = $templateRoots;
 
 echo json_encode($twigMetadata, JSON_PRETTY_PRINT) . PHP_EOL;

--- a/packages/language-server/src/twigEnvironment/CraftTwigEnvironment.ts
+++ b/packages/language-server/src/twigEnvironment/CraftTwigEnvironment.ts
@@ -3,12 +3,11 @@ import { EmptyEnvironment, IFrameworkTwigEnvironment } from './IFrameworkTwigEnv
 import { PhpUtilPath } from './PhpUtilPath';
 import { TwigEnvironmentArgs } from './TwigEnvironmentArgs';
 import { SymfonyTwigDebugJsonOutput, parseDebugTwigOutput } from './symfony/parseDebugTwigOutput';
-import { TwigEnvironment } from './types';
+import { TemplatePathMapping, TwigEnvironment } from './types';
 
 export class CraftTwigEnvironment implements IFrameworkTwigEnvironment {
     #environment: TwigEnvironment | null = null;
     readonly routes = Object.freeze({});
-    readonly templateMappings = EmptyEnvironment.templateMappings;
 
     constructor(private readonly _phpExecutor: PhpExecutor) {
     }
@@ -19,6 +18,12 @@ export class CraftTwigEnvironment implements IFrameworkTwigEnvironment {
 
     async refresh({ workspaceDirectory }: TwigEnvironmentArgs): Promise<void> {
         this.#environment = await this.#loadEnvironment(workspaceDirectory);
+    }
+
+    get templateMappings(): TemplatePathMapping[] {
+        return this.#environment?.LoaderPaths?.length
+            ? this.#environment.LoaderPaths
+            : EmptyEnvironment.templateMappings;
     }
 
     async #loadEnvironment(workspaceDirectory: string): Promise<TwigEnvironment | null> {


### PR DESCRIPTION
Add functionality to try to find a Craft installation in a subfolder of the workspace directory if not found in the workspace directly.
This also adds Craft's overridable template path defined in bootstrap/bootstrap.php to the loader paths.

Fixes #40 