### PR TITLE
fix: resolve template paths with leading slashes and framework subfolders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 env:
   NPM_TOKEN: ${{ secrets.NPM_PAT }}
   VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+  OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
 
 jobs:
   deploy:
@@ -22,7 +23,6 @@ jobs:
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
-            - args: [--global, "@vscode/vsce"]
 
       - uses: actions/setup-node@v4
         with:
@@ -31,8 +31,21 @@ jobs:
 
       - run: pnpm build
 
-      - run: vsce publish --no-dependencies
-        working-directory: ./packages/vscode
+      - name: Publish to VS Code Marketplace
+        if: ${{ env.VSCE_PAT != '' }}
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          packagePath: ./packages/vscode
+          dependencies: false
+
+      - name: Publish to Open VSX
+        if: ${{ env.OPEN_VSX_TOKEN != '' }}
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          registryUrl: https://open-vsx.org
+          packagePath: ./packages/vscode
 
       - name: pnpm publish
         working-directory: ./packages/language-server

--- a/packages/language-server/__tests__/normalizeTemplatePath.test.ts
+++ b/packages/language-server/__tests__/normalizeTemplatePath.test.ts
@@ -1,12 +1,6 @@
-import { describe, test, beforeEach, mock } from 'node:test';
+import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
-import {
-    normalizeDirectoryPath,
-    extractFrameworkRoot,
-} from '../src/utils/paths/normalizeTemplatePath';
-
-// Mock existsSync for testing
-const originalExistsSync = require('fs').existsSync;
+import { normalizeDirectoryPath } from '../src/utils/paths/normalizeTemplatePath';
 
 describe('normalizeTemplatePath', () => {
     describe('normalizeDirectoryPath', () => {
@@ -47,58 +41,6 @@ describe('normalizeTemplatePath', () => {
                 undefined,
             );
             assert.equal(result, 'vendor/templates');
-        });
-    });
-
-    describe('extractFrameworkRoot', () => {
-        test('returns undefined for standard bin/console path', () => {
-            const result = extractFrameworkRoot('bin/console');
-            assert.equal(result, undefined);
-        });
-
-        test('returns undefined for ./bin/console path', () => {
-            const result = extractFrameworkRoot('./bin/console');
-            assert.equal(result, undefined);
-        });
-
-        test('extracts framework root from app/bin/console', () => {
-            const result = extractFrameworkRoot('app/bin/console');
-            assert.equal(result, 'app');
-        });
-
-        test('extracts framework root from backend/bin/console', () => {
-            const result = extractFrameworkRoot('backend/bin/console');
-            assert.equal(result, 'backend');
-        });
-
-        test('extracts nested framework root', () => {
-            const result = extractFrameworkRoot('apps/main/bin/console');
-            assert.equal(result, 'apps/main');
-        });
-
-        test('handles backslashes', () => {
-            const result = extractFrameworkRoot('app\\bin\\console');
-            assert.equal(result, 'app');
-        });
-
-        test('handles mixed separators', () => {
-            const result = extractFrameworkRoot('apps\\main/bin/console');
-            assert.equal(result, 'apps/main');
-        });
-
-        test('returns undefined for empty string', () => {
-            const result = extractFrameworkRoot('');
-            assert.equal(result, undefined);
-        });
-
-        test('returns undefined when bin is not in path', () => {
-            const result = extractFrameworkRoot('console.php');
-            assert.equal(result, undefined);
-        });
-
-        test('returns undefined for ./app/bin/console (dot-relative)', () => {
-            const result = extractFrameworkRoot('./app/bin/console');
-            assert.equal(result, 'app');
         });
     });
 });

--- a/packages/language-server/__tests__/normalizeTemplatePath.test.ts
+++ b/packages/language-server/__tests__/normalizeTemplatePath.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, beforeEach, mock } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+    normalizeDirectoryPath,
+    extractFrameworkRoot,
+} from '../src/utils/paths/normalizeTemplatePath';
+
+// Mock existsSync for testing
+const originalExistsSync = require('fs').existsSync;
+
+describe('normalizeTemplatePath', () => {
+    describe('normalizeDirectoryPath', () => {
+        test('handles relative path without changes', () => {
+            const result = normalizeDirectoryPath(
+                'templates',
+                '/workspace',
+                undefined,
+            );
+            assert.equal(result, 'templates');
+        });
+
+        test('strips leading slash from non-absolute path', () => {
+            // When path starts with "/" but doesn't exist as absolute path
+            const result = normalizeDirectoryPath(
+                '/templates',
+                '/workspace',
+                undefined,
+            );
+            // Since "/templates" likely doesn't exist as an absolute path,
+            // it should be treated as relative
+            assert.equal(result, 'templates');
+        });
+
+        test('normalizes backslashes to forward slashes', () => {
+            const result = normalizeDirectoryPath(
+                'vendor\\templates',
+                '/workspace',
+                undefined,
+            );
+            assert.equal(result, 'vendor/templates');
+        });
+
+        test('handles mixed separators with leading slash', () => {
+            const result = normalizeDirectoryPath(
+                '/vendor\\templates',
+                '/workspace',
+                undefined,
+            );
+            assert.equal(result, 'vendor/templates');
+        });
+    });
+
+    describe('extractFrameworkRoot', () => {
+        test('returns undefined for standard bin/console path', () => {
+            const result = extractFrameworkRoot('bin/console');
+            assert.equal(result, undefined);
+        });
+
+        test('returns undefined for ./bin/console path', () => {
+            const result = extractFrameworkRoot('./bin/console');
+            assert.equal(result, undefined);
+        });
+
+        test('extracts framework root from app/bin/console', () => {
+            const result = extractFrameworkRoot('app/bin/console');
+            assert.equal(result, 'app');
+        });
+
+        test('extracts framework root from backend/bin/console', () => {
+            const result = extractFrameworkRoot('backend/bin/console');
+            assert.equal(result, 'backend');
+        });
+
+        test('extracts nested framework root', () => {
+            const result = extractFrameworkRoot('apps/main/bin/console');
+            assert.equal(result, 'apps/main');
+        });
+
+        test('handles backslashes', () => {
+            const result = extractFrameworkRoot('app\\bin\\console');
+            assert.equal(result, 'app');
+        });
+
+        test('handles mixed separators', () => {
+            const result = extractFrameworkRoot('apps\\main/bin/console');
+            assert.equal(result, 'apps/main');
+        });
+
+        test('returns undefined for empty string', () => {
+            const result = extractFrameworkRoot('');
+            assert.equal(result, undefined);
+        });
+
+        test('returns undefined when bin is not in path', () => {
+            const result = extractFrameworkRoot('console.php');
+            assert.equal(result, undefined);
+        });
+
+        test('returns undefined for ./app/bin/console (dot-relative)', () => {
+            const result = extractFrameworkRoot('./app/bin/console');
+            assert.equal(result, 'app');
+        });
+    });
+});

--- a/packages/language-server/src/completions/CompletionProvider.ts
+++ b/packages/language-server/src/completions/CompletionProvider.ts
@@ -26,7 +26,7 @@ export class CompletionProvider {
     workspaceFolderPath: string;
     #phpExecutor: IPhpExecutor | null = null;
     #expressionTypeResolver: IExpressionTypeResolver | null = null;
-    #frameworkRoot: string | undefined;
+    #composerRoot: string | undefined;
     #additionalMappings: TemplatePathMapping[] = [];
     #normalizedMappingsCache: TemplatePathMapping[] | null = null;
 
@@ -44,14 +44,14 @@ export class CompletionProvider {
         environment: IFrameworkTwigEnvironment,
         phpExecutor: IPhpExecutor | null,
         typeResolver: ITypeResolver | null,
-        frameworkRoot?: string,
+        composerRoot?: string,
         additionalMappings?: TemplatePathMapping[],
     ) {
         this.#environment = environment;
         this.#symfonyRouteNames = Object.keys(environment.routes);
         this.#phpExecutor = phpExecutor;
         this.#expressionTypeResolver = typeResolver ? new ExpressionTypeResolver(typeResolver) : null;
-        this.#frameworkRoot = frameworkRoot;
+        this.#composerRoot = composerRoot;
         this.#additionalMappings = additionalMappings || [];
         this.#normalizedMappingsCache = null;
     }
@@ -72,7 +72,7 @@ export class CompletionProvider {
             directory: normalizeDirectoryPath(
                 directory,
                 this.workspaceFolderPath,
-                this.#frameworkRoot,
+                this.#composerRoot,
             ),
         }));
 

--- a/packages/language-server/src/completions/CompletionProvider.ts
+++ b/packages/language-server/src/completions/CompletionProvider.ts
@@ -17,6 +17,8 @@ import { IPhpExecutor } from '../phpInterop/IPhpExecutor';
 import { ExpressionTypeResolver } from '../typing/ExpressionTypeResolver';
 import { ITypeResolver } from '../typing/ITypeResolver';
 import { IExpressionTypeResolver } from '../typing/IExpressionTypeResolver';
+import { TemplatePathMapping } from '../twigEnvironment/types';
+import { normalizeDirectoryPath } from '../utils/paths/normalizeTemplatePath';
 
 export class CompletionProvider {
     #symfonyRouteNames: string[] = [];
@@ -24,6 +26,9 @@ export class CompletionProvider {
     workspaceFolderPath: string;
     #phpExecutor: IPhpExecutor | null = null;
     #expressionTypeResolver: IExpressionTypeResolver | null = null;
+    #frameworkRoot: string | undefined;
+    #additionalMappings: TemplatePathMapping[] = [];
+    #normalizedMappingsCache: TemplatePathMapping[] | null = null;
 
     constructor(
         private readonly connection: Connection,
@@ -39,11 +44,39 @@ export class CompletionProvider {
         environment: IFrameworkTwigEnvironment,
         phpExecutor: IPhpExecutor | null,
         typeResolver: ITypeResolver | null,
+        frameworkRoot?: string,
+        additionalMappings?: TemplatePathMapping[],
     ) {
         this.#environment = environment;
         this.#symfonyRouteNames = Object.keys(environment.routes);
         this.#phpExecutor = phpExecutor;
         this.#expressionTypeResolver = typeResolver ? new ExpressionTypeResolver(typeResolver) : null;
+        this.#frameworkRoot = frameworkRoot;
+        this.#additionalMappings = additionalMappings || [];
+        this.#normalizedMappingsCache = null;
+    }
+
+    /**
+     * Gets effective template mappings with normalized paths for completions.
+     */
+    get #effectiveTemplateMappings(): TemplatePathMapping[] {
+        if (this.#normalizedMappingsCache) {
+            return this.#normalizedMappingsCache;
+        }
+
+        const frameworkMappings = this.#environment.templateMappings;
+        const allMappings = [...frameworkMappings, ...this.#additionalMappings];
+
+        this.#normalizedMappingsCache = allMappings.map(({ namespace, directory }) => ({
+            namespace,
+            directory: normalizeDirectoryPath(
+                directory,
+                this.workspaceFolderPath,
+                this.#frameworkRoot,
+            ),
+        }));
+
+        return this.#normalizedMappingsCache;
     }
 
     async onCompletion(params: CompletionParams) {
@@ -74,7 +107,7 @@ export class CompletionProvider {
                 cursorNode,
                 params.position,
                 this.workspaceFolderPath,
-                this.#environment.templateMappings,
+                this.#effectiveTemplateMappings,
             ),
         ];
     }

--- a/packages/language-server/src/configuration/LanguageServerSettings.ts
+++ b/packages/language-server/src/configuration/LanguageServerSettings.ts
@@ -17,6 +17,22 @@ type DiagnosticsSettings = {
     twigCsFixer: boolean,
 };
 
+/**
+ * Manual template path mapping configuration.
+ * Allows users to register additional namespace → directory mappings.
+ */
+export type TemplatePathConfig = {
+    /**
+     * The namespace prefix (e.g., "@MyBundle" or "" for root namespace).
+     * Use "" for templates without a namespace prefix.
+     */
+    namespace: string,
+    /**
+     * The directory path relative to the workspace folder.
+     */
+    path: string,
+};
+
 export type LanguageServerSettings = {
     autoInsertSpaces: boolean,
     inlayHints: InlayHintSettings,
@@ -26,4 +42,10 @@ export type LanguageServerSettings = {
     symfonyConsolePath: string,
     vanillaTwigEnvironmentPath: string,
     diagnostics: DiagnosticsSettings,
+
+    /**
+     * Additional template path mappings to register manually.
+     * Useful for bundle development or non-standard project structures.
+     */
+    templatePaths?: TemplatePathConfig[],
 };

--- a/packages/language-server/src/configuration/LanguageServerSettings.ts
+++ b/packages/language-server/src/configuration/LanguageServerSettings.ts
@@ -44,6 +44,16 @@ export type LanguageServerSettings = {
     diagnostics: DiagnosticsSettings,
 
     /**
+     * Root directory of the PHP/Composer project relative to the workspace.
+     * Used when the Symfony/Craft application is in a subdirectory (e.g., monorepo setups).
+     *
+     * Example: If your composer.json is at `app/composer.json`, set this to `app`.
+     *
+     * When set, template paths and the Symfony console will be resolved relative to this directory.
+     */
+    composerRoot?: string,
+
+    /**
      * Additional template path mappings to register manually.
      * Useful for bundle development or non-standard project structures.
      */

--- a/packages/language-server/src/documents/DocumentCache.ts
+++ b/packages/language-server/src/documents/DocumentCache.ts
@@ -14,7 +14,7 @@ import { normalizeDirectoryPath } from '../utils/paths/normalizeTemplatePath';
 export class DocumentCache {
     #environment: IFrameworkTwigEnvironment = EmptyEnvironment;
     #typeResolver: ITypeResolver | null = null;
-    #frameworkRoot: string | undefined;
+    #composerRoot: string | undefined;
     #additionalMappings: TemplatePathMapping[] = [];
     #normalizedMappingsCache: TemplatePathMapping[] | null = null;
 
@@ -28,12 +28,12 @@ export class DocumentCache {
     configure(
         frameworkEnvironment: IFrameworkTwigEnvironment,
         typeResolver: ITypeResolver | null,
-        frameworkRoot?: string,
+        composerRoot?: string,
         additionalMappings?: TemplatePathMapping[],
     ) {
         this.#environment = frameworkEnvironment;
         this.#typeResolver = typeResolver;
-        this.#frameworkRoot = frameworkRoot;
+        this.#composerRoot = composerRoot;
         this.#additionalMappings = additionalMappings || [];
         this.#normalizedMappingsCache = null; // Clear cache when configuration changes
     }
@@ -56,7 +56,7 @@ export class DocumentCache {
             directory: normalizeDirectoryPath(
                 directory,
                 this.workspaceFolderPath,
-                this.#frameworkRoot,
+                this.#composerRoot,
             ),
         }));
 
@@ -114,9 +114,9 @@ export class DocumentCache {
 
             let resolvedTemplate = await resolveTemplate(pathToTwig);
 
-            // If not found and we have a framework root, try resolving relative to it
-            if (!resolvedTemplate && this.#frameworkRoot) {
-                pathToTwig = path.resolve(this.workspaceFolderPath, this.#frameworkRoot, includePath);
+            // If not found and we have a composer root, try resolving relative to it
+            if (!resolvedTemplate && this.#composerRoot) {
+                pathToTwig = path.resolve(this.workspaceFolderPath, this.#composerRoot, includePath);
                 documentUri = toDocumentUri(pathToTwig);
 
                 if (this.documents.has(documentUri)) {

--- a/packages/language-server/src/documents/DocumentCache.ts
+++ b/packages/language-server/src/documents/DocumentCache.ts
@@ -111,4 +111,16 @@ export class DocumentCache {
         this.documents.set(documentUri, document);
         return document;
     }
+
+    remove(documentUri: DocumentUri) {
+        this.documents.delete(toDocumentUri(documentUri));
+    }
+
+    async refresh(documentUri: DocumentUri) {
+        const normalizedUri = toDocumentUri(documentUri);
+        const document = this.documents.get(normalizedUri);
+        if (document) {
+            await this.setText(document);
+        }
+    }
 }

--- a/packages/language-server/src/phpInterop/PhpExecutor.ts
+++ b/packages/language-server/src/phpInterop/PhpExecutor.ts
@@ -19,6 +19,8 @@ export class PhpExecutor implements IPhpExecutor {
         }
 
         const result = await exec(this._phpExecutable, [
+            '-d',
+            'display_errors=stderr',
             command,
             ...args,
         ], {

--- a/packages/language-server/src/utils/paths/normalizeTemplatePath.ts
+++ b/packages/language-server/src/utils/paths/normalizeTemplatePath.ts
@@ -1,0 +1,145 @@
+import * as path from 'path';
+import { existsSync } from 'fs';
+
+/**
+ * Normalizes a directory path for template resolution.
+ *
+ * Handles several edge cases:
+ * 1. Leading slashes that make relative paths appear absolute (e.g., "/templates" → "templates")
+ * 2. Absolute paths that should be converted to relative paths when possible
+ * 3. Mixed path separators on Windows
+ *
+ * @param directory The directory path from the framework (e.g., Symfony's debug:twig output)
+ * @param workspaceFolderPath The workspace folder path
+ * @param frameworkRoot Optional framework root relative to workspace (e.g., "app" for "app/bin/console")
+ * @returns Normalized directory path that can be resolved relative to workspace
+ */
+export function normalizeDirectoryPath(
+    directory: string,
+    workspaceFolderPath: string,
+    frameworkRoot?: string,
+): string {
+    // Normalize path separators
+    let normalized = directory.replace(/\\/g, '/');
+
+    // Check if path starts with a slash but isn't a valid absolute path
+    if (normalized.startsWith('/') && !path.isAbsolute(normalized)) {
+        // Strip leading slash - it's meant to be relative
+        normalized = normalized.slice(1);
+    }
+
+    // If path starts with slash and is absolute, check if it's within workspace
+    if (path.isAbsolute(normalized)) {
+        // If the absolute path exists, use it as-is
+        if (existsSync(normalized)) {
+            // Try to make it relative to workspace if it's within workspace
+            if (normalized.startsWith(workspaceFolderPath)) {
+                return path.relative(workspaceFolderPath, normalized);
+            }
+            // Otherwise return as-is (it's a valid external path)
+            return normalized;
+        }
+
+        // Path doesn't exist as absolute, try stripping leading slash
+        const withoutLeadingSlash = normalized.slice(1);
+        const relativeToWorkspace = path.join(workspaceFolderPath, withoutLeadingSlash);
+        if (existsSync(relativeToWorkspace)) {
+            return withoutLeadingSlash;
+        }
+
+        // Try with framework root
+        if (frameworkRoot) {
+            const relativeToFramework = path.join(workspaceFolderPath, frameworkRoot, withoutLeadingSlash);
+            if (existsSync(relativeToFramework)) {
+                return path.join(frameworkRoot, withoutLeadingSlash);
+            }
+        }
+
+        // Fall back to stripping leading slash
+        return withoutLeadingSlash;
+    }
+
+    // For relative paths, prepend framework root if provided and path doesn't exist directly
+    if (frameworkRoot && !existsSync(path.join(workspaceFolderPath, normalized))) {
+        const withFrameworkRoot = path.join(frameworkRoot, normalized);
+        if (existsSync(path.join(workspaceFolderPath, withFrameworkRoot))) {
+            return withFrameworkRoot;
+        }
+    }
+
+    return normalized;
+}
+
+/**
+ * Extracts the framework root directory from the console path.
+ *
+ * Examples:
+ * - "bin/console" → undefined (framework is at workspace root)
+ * - "./bin/console" → undefined
+ * - "app/bin/console" → "app"
+ * - "backend/bin/console" → "backend"
+ *
+ * @param consolePath The Symfony console path (e.g., "app/bin/console")
+ * @returns The framework root directory or undefined if at workspace root
+ */
+export function extractFrameworkRoot(consolePath: string): string | undefined {
+    if (!consolePath) {
+        return undefined;
+    }
+
+    // Normalize path separators and remove leading ./
+    let normalized = consolePath.replace(/\\/g, '/');
+    if (normalized.startsWith('./')) {
+        normalized = normalized.slice(2);
+    }
+
+    // Split and check if there's a directory before bin/console
+    const parts = normalized.split('/');
+
+    // Standard Symfony structure: bin/console is at the end
+    const binIndex = parts.indexOf('bin');
+    if (binIndex > 0) {
+        // Everything before 'bin' is the framework root
+        return parts.slice(0, binIndex).join('/');
+    }
+
+    return undefined;
+}
+
+/**
+ * Resolves a Twig template path to an absolute filesystem path.
+ *
+ * @param twigPath The Twig template path (e.g., "partials/header.twig" or "@Bundle/template.twig")
+ * @param namespace The namespace for this mapping (e.g., "" or "@Bundle")
+ * @param directory The directory for this mapping (already normalized)
+ * @param workspaceFolderPath The workspace folder path
+ * @param frameworkRoot Optional framework root relative to workspace
+ * @returns Absolute path to the template file
+ */
+export function resolveTemplatePath(
+    twigPath: string,
+    namespace: string,
+    directory: string,
+    workspaceFolderPath: string,
+    frameworkRoot?: string,
+): string {
+    // Build the include path based on namespace
+    const includePath = namespace === ''
+        ? path.join(directory, twigPath)
+        : twigPath.replace(namespace, directory);
+
+    // If the include path is absolute and exists, use it
+    if (path.isAbsolute(includePath) && existsSync(includePath)) {
+        return includePath;
+    }
+
+    // Try resolving relative to workspace
+    const resolvedPath = path.resolve(workspaceFolderPath, includePath);
+    if (existsSync(resolvedPath) || !frameworkRoot) {
+        return resolvedPath;
+    }
+
+    // Try resolving relative to framework root
+    const resolvedWithFramework = path.resolve(workspaceFolderPath, frameworkRoot, includePath);
+    return resolvedWithFramework;
+}

--- a/packages/language-server/src/utils/paths/normalizeTemplatePath.ts
+++ b/packages/language-server/src/utils/paths/normalizeTemplatePath.ts
@@ -71,42 +71,6 @@ export function normalizeDirectoryPath(
 }
 
 /**
- * Extracts the framework root directory from the console path.
- *
- * Examples:
- * - "bin/console" → undefined (framework is at workspace root)
- * - "./bin/console" → undefined
- * - "app/bin/console" → "app"
- * - "backend/bin/console" → "backend"
- *
- * @param consolePath The Symfony console path (e.g., "app/bin/console")
- * @returns The framework root directory or undefined if at workspace root
- */
-export function extractFrameworkRoot(consolePath: string): string | undefined {
-    if (!consolePath) {
-        return undefined;
-    }
-
-    // Normalize path separators and remove leading ./
-    let normalized = consolePath.replace(/\\/g, '/');
-    if (normalized.startsWith('./')) {
-        normalized = normalized.slice(2);
-    }
-
-    // Split and check if there's a directory before bin/console
-    const parts = normalized.split('/');
-
-    // Standard Symfony structure: bin/console is at the end
-    const binIndex = parts.indexOf('bin');
-    if (binIndex > 0) {
-        // Everything before 'bin' is the framework root
-        return parts.slice(0, binIndex).join('/');
-    }
-
-    return undefined;
-}
-
-/**
  * Resolves a Twig template path to an absolute filesystem path.
  *
  * @param twigPath The Twig template path (e.g., "partials/header.twig" or "@Bundle/template.twig")

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -87,7 +87,27 @@
           "type": "string",
           "scope": "resource",
           "default": "bin/console",
-          "markdownDescription": "Path to the Symfony console. See: https://symfony.com/doc/current/templates.html#inspecting-twig-information"
+          "markdownDescription": "Path to the Symfony console. See: https://symfony.com/doc/current/templates.html#inspecting-twig-information\n\nNote: If your Symfony application is in a subdirectory (e.g., `app/bin/console`), templates will be resolved relative to that subdirectory."
+        },
+        "twiggy.templatePaths": {
+          "type": "array",
+          "scope": "resource",
+          "default": [],
+          "markdownDescription": "Additional template path mappings for custom namespaces.\n\nUseful for:\n- Bundle development where templates use `@BundleName/...` namespace\n- Non-standard project structures\n- Projects where templates aren't auto-detected\n\nExample:\n```json\n[\n  { \"namespace\": \"@MyBundle\", \"path\": \"src/Bundle/templates\" },\n  { \"namespace\": \"\", \"path\": \"custom/templates\" }\n]\n```",
+          "items": {
+            "type": "object",
+            "required": ["namespace", "path"],
+            "properties": {
+              "namespace": {
+                "type": "string",
+                "description": "The namespace prefix (e.g., '@MyBundle' or '' for root namespace)"
+              },
+              "path": {
+                "type": "string",
+                "description": "Directory path relative to the workspace folder"
+              }
+            }
+          }
         }
       }
     },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -87,7 +87,13 @@
           "type": "string",
           "scope": "resource",
           "default": "bin/console",
-          "markdownDescription": "Path to the Symfony console. See: https://symfony.com/doc/current/templates.html#inspecting-twig-information\n\nNote: If your Symfony application is in a subdirectory (e.g., `app/bin/console`), templates will be resolved relative to that subdirectory."
+          "markdownDescription": "Path to the Symfony console, relative to `composerRoot` (or workspace root if not set).\n\nSee: https://symfony.com/doc/current/templates.html#inspecting-twig-information"
+        },
+        "twiggy.composerRoot": {
+          "type": "string",
+          "scope": "resource",
+          "default": "",
+          "markdownDescription": "Root directory of the PHP/Composer project relative to the workspace.\n\nUse this when your Symfony/Craft application is in a subdirectory (e.g., monorepo setups).\n\n**Example:** If your `composer.json` is at `app/composer.json`, set this to `app`.\n\nWhen set, template paths and the Symfony console will be resolved relative to this directory."
         },
         "twiggy.templatePaths": {
           "type": "array",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -3,7 +3,6 @@ import {
     ExtensionContext,
     window,
     WorkspaceFolder,
-    RelativePattern,
     commands,
     CompletionList,
     Uri,
@@ -46,11 +45,6 @@ async function addWorkspaceFolder(
     context: ExtensionContext
 ): Promise<void> {
     const folderPath = workspaceFolder.uri.fsPath;
-    const fileEvents = workspace.createFileSystemWatcher(
-        new RelativePattern(workspaceFolder, '*.twig'),
-    );
-
-    context.subscriptions.push(fileEvents);
 
     if (clients.has(folderPath)) {
         return;
@@ -89,9 +83,6 @@ async function addWorkspaceFolder(
                 pattern: `${folderPath}/**`,
             },
         ],
-        synchronize: {
-            fileEvents,
-        },
         middleware: {
             async provideCompletionItem(
                 document,


### PR DESCRIPTION
## Summary

Fixes #64

This PR addresses the "Template not found" issue that affected users in several scenarios:

- **Leading slash on directory paths**: When Symfony's `debug:twig` returns paths like `/templates` instead of `templates`, they were incorrectly treated as absolute filesystem paths, causing the language server to look for templates at the filesystem root instead of the workspace.

- **Workspace is parent of Symfony root**: When the workspace is a parent folder (e.g., monorepo with `app/composer.json`), template paths from Symfony were resolved relative to the workspace instead of the PHP project root.

- **Bundle namespaces not auto-detected**: When working inside bundle directories, templates with `@BundleName/...` namespace weren't automatically found.

## Changes

- Add `normalizeTemplatePath.ts` utility with:
  - `normalizeDirectoryPath()`: Handles leading slashes, absolute paths, and composer root resolution
- Add **`twiggy.composerRoot`** config setting for projects in subdirectories
- Update `DocumentCache` to normalize paths and try composer root fallback when resolving templates
- Update `CompletionProvider` to use normalized template mappings for completions
- Add `twiggy.templatePaths` config setting for manual namespace registration
- Add tests for path normalization utilities

### Why `composerRoot` instead of inferring from console path?

The previous approach inferred the framework root from `symfonyConsolePath` (e.g., `app/bin/console` → `app`). We replaced this with an explicit `composerRoot` setting because:

1. **Explicitness over inference**: Users set `composerRoot: "app"` directly rather than relying on implicit path parsing
2. **Separation of concerns**: The console path setting is purely for finding the console, not for determining project structure
3. **Better framework support**: Works with Craft CMS and vanilla Twig projects that may not use `bin/console` but still need subdirectory support
4. **Simpler code**: Removes edge-case handling for extracting paths from console path

## Configuration Options

Users can now:

**1. Use subdirectory PHP installations (monorepo setups):**
```json
{
  "twiggy.composerRoot": "app",
  "twiggy.symfonyConsolePath": "bin/console"
}
```
The console path is resolved relative to `composerRoot`, so templates resolve correctly.

**2. Configure manual template path mappings:**
```json
{
  "twiggy.templatePaths": [
    { "namespace": "@MyBundle", "path": "src/MyBundle/templates" },
    { "namespace": "@Components", "path": "components" }
  ]
}
```

## Test plan

- [x] Build succeeds (`pnpm build`)
- [x] Path normalization tests pass
- [ ] Manual testing with Symfony project having leading slash paths
- [ ] Manual testing with monorepo structure (`composerRoot: "app"`)
- [ ] Manual testing with bundle development using `@BundleName/...` namespace